### PR TITLE
Dependency updates for Java 11 compatibility. 

### DIFF
--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -20,6 +20,9 @@
         <bundle>wrap:mvn:org.apache.httpcomponents/httpclient/${apache-http-client-version}</bundle>
         <bundle>wrap:mvn:org.apache.httpcomponents/httpcore/${apache-http-core-version}</bundle>
         <bundle>mvn:commons-codec/commons-codec/${commons-codec-version}</bundle>
+        <bundle>mvn:org.eclipse.persistence/org.eclipse.persistence.moxy/${eclipselinkVersion}</bundle>
+        <bundle>mvn:org.eclipse.persistence/org.eclipse.persistence.asm/2.7.8</bundle>
+        <bundle>mvn:org.eclipse.persistence/org.eclipse.persistence.core/${eclipselinkVersion}</bundle>
         <!--
         -->
         <bundle>mvn:org.quartz-scheduler/quartz/${quartzVersion}</bundle>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -17,7 +17,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Karaf-Commands>*</Karaf-Commands>
@@ -83,6 +83,22 @@
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.moxy</artifactId>
             <version>${eclipselinkVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.asm</artifactId>
+            <version>2.7.8</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>3.0.0</version>
+            <scope>runtime</scope>
         </dependency>
         <!-- MOXy relies on javax.mail classes for Base64 decoding -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,17 +10,17 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <guava.version>23.1-jre</guava.version>
+        <guava.version>33.3.0-jre</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <java.version>1.8</java.version>
-        <junit.version>4.12</junit.version>
-        <karaf.version>4.1.5</karaf.version>
-        <log4j.version>2.17.1</log4j.version>
-        <mockito.version>2.18.0</mockito.version>
+        <java.version>11</java.version>
+        <junit.version>4.13.2</junit.version>
+        <karaf.version>4.3.10</karaf.version>
+        <log4j.version>2.23.1</log4j.version>
+        <mockito.version>5.11.0</mockito.version>
         <okhttp.version>3.10.0</okhttp.version>
         <okio.bundle.version>1.14.0_1</okio.bundle.version>
         <okhttp.bundle.version>3.10.0_2</okhttp.bundle.version>
-        <opennms.api.version>0.1.0</opennms.api.version>
+        <opennms.api.version>1.6.0</opennms.api.version>
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
@@ -134,7 +134,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>5.1.2</version>
                     <extensions>true</extensions>
                     <configuration>
                         <instructions>


### PR DESCRIPTION
 This branch will compile with Java 11 to an installable karfile and successfully installs in a modern Horizon (33 at this time)

Some of this may not be absolutely necessary, but my iterative (read: trial and error) process made these changes until it both compiled with JDK11 and loaded in H33.